### PR TITLE
Integrate SMP400 gauges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 )
 
 require (
+	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,11 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/oliveagle/jsonpath"
+	"github.com/PaesslerAG/jsonpath"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -23,7 +23,38 @@ var (
 	addr = flag.String("listen-address", ":9109", "The address to listen on for HTTP requests.")
 )
 
-var uris = []string{
+var uris = []string{}
+
+var uris_smp400 = []string{
+	"/unit/name",
+	"/unit/temp/internal",
+	"/unit/temp/board",
+	"/unit/temp/cpu",
+	"/unit/cpu_usage",
+	"/unit/memory_usage",
+	"/record/free_space",
+	"/audio/dsp/oid/60002/v", // on smp400, left output meter
+	"/audio/dsp/oid/60003/v", // on smp400, right output meter
+	"/video/in/channel/1",
+	"/video/in/channel/2",
+	"/record/state",
+	"/xtime/date",
+	"/xtime/timezone_offset",
+	"/schedule_ingest/active_service",
+	"/publish/active_service",
+	//state 0 is scheduled 11 is transfer skipped
+	"/schedule/schedule?format=json&field=db_id,state",
+	"/unit/location",
+        "/streamer/control/1/mode", //smp400 replaces /encoder/1/stream_enable; "2" for stream on, instead of "1" on smp300
+        "/streamer/control/2/mode", //smp400 ..
+        "/streamer/control/3/mode", //smp400 ..
+	"/video/out/1/presets/layout/active",
+	"/streamer/rtmp/1",
+	"/streamer/rtmp/2",
+	"/streamer/rtmp/3",
+}
+
+var uris_smp300 = []string{
 	"/unit/name",
 	"/unit/temp/internal",
 	"/unit/temp/board1",
@@ -34,7 +65,9 @@ var uris = []string{
 	"/unit/cpu_usage",
 	"/unit/memory_usage",
 	"/record/free_space",
-	"/audio/dsp/multiple_oid/v?oids=60000,60001",
+//	"/audio/dsp/multiple_oid/v?oids=60000,60001",
+	"/audio/dsp/oid/60000/v",
+	"/audio/dsp/oid/60001/v",
 	"/video/in/channel/1",
 	"/video/in/channel/2",
 	"/record/state",
@@ -54,38 +87,74 @@ var uris = []string{
 	"/streamer/rtmp/3",
 }
 
-var sources = map[string]string{
-	"extron_temp_internal":                     "$[1].result",
-	"extron_temp_board1":                       "$[2].result",
-	"extron_temp_board2":                       "$[3].result",
-	"extron_temp_cpu":                          "$[4].result",
-	"extron_temp_disk":                         "$[5].result.RAW_VALUE",
-	"extron_fan_cpu1":                          "$[6].result.fan_cpu1",
-	"extron_fan_board1":                        "$[6].result.fan_board1",
-	"extron_cpu_usage":                         "$[7].result[0]",
-	"extron_ram_usage":                         "$[8].result",
-	"extron_internal_disk_used":                "$[9].result.internal[0].used",
-	"extron_internal_disk_total":               "$[9].result.internal[0].total",
-	"extron_internal_disk_free":                "$[9].result.internal[0].free_space",
-	"extron_audio_dsp_left":                    "$[10].result.60000",
-	"extron_audio_dsp_right":                   "$[10].result.60001",
-	"extron_video_in_channel_a":                "$[11].result.active_input",
-	"extron_video_in_channel_b":                "$[12].result.active_input",
-	"extron_record_state":                      "$[13].result",
-	"extron_xtime_date":                        "$[14,15].result", //"extron_xtime_timezone_offset":             "$[15].result",
-	"extron_schedule_ingest_active":            "$[16].result.active",
-	"extron_publish_active":                    "$[17].result.active",
-	"extron_schedule_state_upcoming":           "$[18].result[?(@.state == 0 )].state",
-	"extron_schedule_state_transfer_skipped":   "$[18].result[?(@.state == 11 )].state",
-	"extron_schedule_state_transfer_completed": "$[18].result[?(@.state == 5 )].state",
-	"extron_schedule_state_transfer_no_method": "$[18].result[?(@.state == 10 )].state", //unit/location 19
-	"extron_encoder_1_stream_enabled":          "$[20].result",
-	"extron_encoder_2_stream_enabled":          "$[21].result",
-	"extron_encoder_3_stream_enabled":          "$[22].result",
-	"extron_video_out_1_layout":                "$[23].result.active_index",
-	"extron_streamer_1_rtmp":                   "$[24].result.pub_control",
-	"extron_streamer_2_rtmp":                   "$[25].result.pub_control",
-	"extron_streamer_3_rtmp":                   "$[26].result.pub_control",
+var sources = map[string]string{}
+
+var sources_smp300 = map[string]string{
+	"extron_temp_internal":                     `$[? @.meta.uri=="/unit/temp/internal"].result`,
+	"extron_temp_board1":                       `$[? @.meta.uri=="/unit/temp/board1"].result`,
+	"extron_temp_board2":                       `$[? @.meta.uri=="/unit/temp/board2"].result`,
+	"extron_temp_cpu":                          `$[? @.meta.uri=="/unit/temp/cpu"].result`,
+	"extron_temp_disk":                         `$[? @.meta.uri=="/tool/disktemperature"].result.RAW_VALUE`,
+	"extron_fan_cpu1":                          `$[? @.meta.uri=="/unit/fan_speed"].result.fan_cpu1`,
+	"extron_fan_board1":                        `$[? @.meta.uri=="/unit/fan_speed"].result.fan_board1`,
+	"extron_cpu_usage":                         `$[? @.meta.uri=="/unit/cpu_usage"].result[0]`,
+	"extron_ram_usage":                         `$[? @.meta.uri=="/unit/memory_usage"].result`,
+	"extron_internal_disk_used":                `$[? @.meta.uri=="/record/free_space"].result.internal[0].used`,
+	"extron_internal_disk_total":               `$[? @.meta.uri=="/record/free_space"].result.internal[0].total`,
+	"extron_internal_disk_free":                `$[? @.meta.uri=="/record/free_space"].result.internal[0].free_space`,
+  	"extron_audio_dsp_left":                    `$[? @.meta.uri=="/audio/dsp/oid/60000/v"].result`,
+  	"extron_audio_dsp_right":                   `$[? @.meta.uri=="/audio/dsp/oid/60001/v"].result`,
+	"extron_video_in_channel_a":                `$[? @.meta.uri=="/video/in/channel/1"].result.active_input`,
+	"extron_video_in_channel_b":                `$[? @.meta.uri=="/video/in/channel/2"].result.active_input`,
+	"extron_record_state":                      `$[? @.meta.uri=="/record/state"].result`,
+	"extron_xtime_date":                        `$[? @.meta.uri=="/xtime/date"].result`,
+	"extron_schedule_ingest_active":            `$[? @.meta.uri=="/schedule_ingest/active_service"].result.active`,
+	"extron_publish_active":                    `$[? @.meta.uri=="/publish/active_service"].result.active`,
+	"extron_schedule_state_upcoming":           `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 0 )].state`,
+	"extron_schedule_state_transfer_skipped":   `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 11 )].state`,
+	"extron_schedule_state_transfer_completed": `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 5 )].state`,
+	"extron_schedule_state_transfer_no_method": `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 10 )].state`, //unit/location 19
+	"extron_encoder_1_stream_enabled":          `$[? @.meta.uri=="/encoder/1/stream_enable"].result`,
+	"extron_encoder_2_stream_enabled":          `$[? @.meta.uri=="/encoder/2/stream_enable"].result`,
+	"extron_encoder_3_stream_enabled":          `$[? @.meta.uri=="/encoder/3/stream_enable"].result`,
+	"extron_video_out_1_layout":                `$[? @.meta.uri=="/video/out/1/presets/layout/active"].result.active_index`,
+	"extron_streamer_1_rtmp":                   `$[? @.meta.uri=="/streamer/rtmp/1"].result.pub_control`,
+	"extron_streamer_2_rtmp":                   `$[? @.meta.uri=="/streamer/rtmp/2"].result.pub_control`,
+	"extron_streamer_3_rtmp":                   `$[? @.meta.uri=="/streamer/rtmp/3"].result.pub_control`,
+}
+
+
+var sources_smp400 = map[string]string{
+	"extron_temp_internal":                     `$[? @.meta.uri=="/unit/temp/internal"].result`,
+	"extron_temp_board1":                       `$[? @.meta.uri=="/unit/temp/board"].result`,
+	"extron_temp_cpu":                          `$[? @.meta.uri=="/unit/temp/cpu"].result`,
+	"extron_cpu_usage":                         `$[? @.meta.uri=="/unit/cpu_usage"].result[0]`,
+	"extron_ram_usage":                         `$[? @.meta.uri=="/unit/memory_usage"].result`,
+	"extron_internal_disk_used":                `$[? @.meta.uri=="/record/free_space"].result.internal[0].used`,
+	"extron_internal_disk_total":               `$[? @.meta.uri=="/record/free_space"].result.internal[0].total`,
+	"extron_internal_disk_free":                `$[? @.meta.uri=="/record/free_space"].result.internal[0].free_space`,
+	"extron_audio_dsp_left":                    `$[? @.meta.uri=="/audio/dsp/oid/60002/v"].result`,
+	"extron_audio_dsp_right":                   `$[? @.meta.uri=="/audio/dsp/oid/60003/v"].result`,
+	"extron_video_in_channel_a":                `$[? @.meta.uri=="/video/in/channel/1"].result.active_input`,
+	"extron_video_in_channel_b":                `$[? @.meta.uri=="/video/in/channel/2"].result.active_input`,
+	"extron_record_state":                      `$[? @.meta.uri=="/record/state"].result.state`,
+	"extron_xtime_date":                        `$[? @.meta.uri=="/xtime/date"].result`,
+	"extron_schedule_ingest_active":            `$[? @.meta.uri=="/schedule_ingest/active_service"].result.active`,
+	"extron_publish_active":                    `$[? @.meta.uri=="/publish/active_service"].result.active`,
+	"extron_schedule_state_upcoming":           `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 0 )].state`,
+	"extron_schedule_state_transfer_skipped":   `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 11 )].state`,
+	"extron_schedule_state_transfer_completed": `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 5 )].state`,
+	"extron_schedule_state_transfer_no_method": `$[? @.meta.uri=="/schedule/schedule?format=json&field=db_id,state"].result[?(@.state == 10 )].state`,
+ 	// extron1 is stream 1 on smp400 and stream 3 on smp300
+  	"extron_encoder_3_stream_enabled":          `$[? @.meta.uri=="/streamer/control/1/mode"].result`,
+ 	// ch_a is stream 2 on smp400 and stream 1 on smp300
+  	"extron_encoder_1_stream_enabled":          `$[? @.meta.uri=="/streamer/control/2/mode"].result`,
+ 	// ch_b is stream 3 on smp400 and stream 2 on smp300
+  	"extron_encoder_2_stream_enabled":          `$[? @.meta.uri=="/streamer/control/3/mode"].result`,
+	"extron_video_out_1_layout":                `$[? @.meta.uri=="/video/out/1/presets/layout/active"].result.active_index`,
+	"extron_streamer_1_rtmp":                   `$[? @.meta.uri=="/streamer/rtmp/1"].result.pub_control`,
+	"extron_streamer_2_rtmp":                   `$[? @.meta.uri=="/streamer/rtmp/2"].result.pub_control`,
+	"extron_streamer_3_rtmp":                   `$[? @.meta.uri=="/streamer/rtmp/3"].result.pub_control`,
 }
 
 var regex = regexp.MustCompile("[^\\.0-9]+")
@@ -143,10 +212,64 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Login and get a cookie as authentication for followup requests
 	target, err := url.Parse(paramTarget)
-	target.Path = "/api/swis/resources"
+	target.Path = "/api/login"
 	payload := r.Header.Get("Authorization")
 
+	cookiereq, err := http.NewRequest("POST", target.String(), nil)
+	if payload != "" {
+		cookiereq.Header.Add("Authorization", payload)
+	}
+	cookieresp, err := client.Do(cookiereq)
+	cookies := cookieresp.Cookies()
+
+	defer cookieresp.Body.Close()
+
+	if err != nil {
+		log.Printf("Response for login cookie was nil, failed: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusGatewayTimeout) // TODO: is there a better http.Error ?
+		return
+	}
+
+	// Get the model info, which decides on SMP300 or SMP400 uris and sources
+	target.Path = "/api/swis/resource/unit/model/name"
+	modelreq, err := http.NewRequest("GET", target.String(), nil)
+	if payload != "" {
+		modelreq.Header.Add("Authorization", payload)
+		for i := range cookies {
+  			modelreq.AddCookie(cookies[i])
+		}	
+	}
+	modelresp, err := client.Do(modelreq)
+
+	defer modelresp.Body.Close()
+
+	modelbytes, err := ioutil.ReadAll(modelresp.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var modeljsonData interface{}
+	json.Unmarshal([]byte(modelbytes), &modeljsonData)
+
+	model, err := jsonpath.Get(`$.result`, modeljsonData)
+
+	if "SMP 401" == model {
+		sources = sources_smp400
+		uris = uris_smp400
+		log.Print("--> Using SMP400 uris and sources")
+	} else {
+		sources = sources_smp300
+		uris = uris_smp300
+		log.Print("--> Using SMP300 uris and sources")
+	}
+
+	log.Print("Model: ", model)
+
+	// Get all the information from the SMP
+	target.Path = "/api/swis/resources"
 	q := target.Query()
 	q.Set("_dc", strconv.FormatInt(time.Now().Unix(), 10))
 	for _, r := range uris {
@@ -157,6 +280,9 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 	req, err := http.NewRequest("GET", target.String(), nil)
 	if payload != "" {
 		req.Header.Add("Authorization", payload)
+		for i := range cookies {
+  			req.AddCookie(cookies[i])
+		}	
 	}
 	resp, err := client.Do(req)
 
@@ -182,18 +308,34 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 
 	var jsonData interface{}
 	json.Unmarshal([]byte(bytes), &jsonData)
+	log.Print("jsonData: ", jsonData)	
 
-	name, err := jsonpath.JsonPathLookup(jsonData, "$[0].result")
-	location, err := jsonpath.JsonPathLookup(jsonData, "$[19].result")
+	name, err := jsonpath.Get(`$[? @.meta.uri=="/unit/name"].result`, jsonData)
+	name, err = jsonpath.Get("$[0]", name)
+	location, err := jsonpath.Get(`$[? @.meta.uri=="/unit/location"].result`, jsonData)
+	location, err = jsonpath.Get("$[0]", location)
+	timezone_offset, err := jsonpath.Get(`$[? @.meta.uri=="/xtime/timezone_offset"].result`, jsonData)
+	timezone_offset, err = jsonpath.Get("$[0]", timezone_offset)
+
+   	log.Print("hello: ", name, " ", location, " ", timezone_offset)
+
 
 	for metricName, jsonPath := range sources {
-		res, err := jsonpath.JsonPathLookup(jsonData, jsonPath)
+		res, err := jsonpath.Get(jsonPath, jsonData)
+		log.Print("Metric: ", metricName, " Res: ", res)
 		if err != nil {
+			log.Print("Metric skipped: ", metricName, " Res: ", res)
 			continue
+		}
+		
+		if len(res.([]interface{})) == 1 { 
+			log.Print("Metric is of length 1: ", metricName, " Res: ", res)
+			res, err = jsonpath.Get("$[0]",res)
 		}
 
 		switch v := res.(type) {
 		case string:
+			log.Print("Metric is of type string: ", metricName, " Res: ", res)
 			str := regex.ReplaceAllString(res.(string), "")
 			if "extron_record_state" == metricName {
 				if res == "recording" {
@@ -211,23 +353,50 @@ func probeHandler(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Values could not be parsed to Float64", http.StatusInternalServerError)
 				return
 			}
+			if "extron_xtime_date" == metricName {
+				t, _ := time.Parse("Mon, 02 Jan 2006 15:4:5 -07:00", res.(string)+" "+timezone_offset.(string))
+				number = float64(t.Unix())
+			}
 			res = number
+			log.Print("Metric was string, is now number: ", metricName, " Res: ", res)
 		case bool:
 			if res.(bool) {
 				res = float64(1)
 			} else {
 				res = float64(0)
 			}
+			log.Print("Metric is of type bool: ", metricName, " Res: ", res)
 		case []interface{}:
 			if "extron_xtime_date" == metricName {
-				t, _ := time.Parse("Mon, 02 Jan 2006 15:4:5 -07:00", v[0].(string)+" "+v[1].(string))
+				t, _ := time.Parse("Mon, 02 Jan 2006 15:4:5 -07:00", v[0].(string)+" "+timezone_offset.(string))
 				res = float64(t.Unix())
 			} else {
 				res = float64(len(v))
 			}
+			log.Print("Metric is of type interface: ", metricName, " Res: ", res)
 		default:
 			res = v
+			match, _ := regexp.MatchString("extron_encoder_._stream_enabled", metricName)
+			if match {
+				if res == float64(2) { // adapt "enabled" state == 2 on smp400 vs == 1 on smp300
+					res = float64(1)
+                        	}
+			}
+			match, _ = regexp.MatchString("extron_audio_dsp.*", metricName)
+			if match {
+				if res.(float64) > 0  { // adapt audio meter level > 0 on smp400 vs < 0 on smp300
+					res = -res.(float64)
+                        	}
+			}
+			match, _ = regexp.MatchString("extron_record_state", metricName)
+			if match {
+				if res.(float64) == 3  { // adapt "paused" state == 3 on smp400 vs == 1 on smp300
+					res = res.(float64)-2
+                        	} 
+			}
+			log.Print("Metric is of type default: ", metricName, " Res: ", res)
 		}
+
 
 		number, ok := res.(float64)
 		if !ok {


### PR DESCRIPTION
Bei mir lokal läuft das für beide, SMP300 und SMP400 ok.

Ich hab, nach Herausfinden der entsprechenden Endpoints der SMP400 vor allem die jsonPath Queries "sprechend" gemacht, und musste dafür eine andere jsonPath-Package verwenden.

Es ist der login-Request hinzugekommen, um ein Cookie zu bekommen.
Und ein Initia-Request nach dem Model-Namen, damit die jeweils richtigen Endpoints verwendet werden.
Manche zurückgegebenen Werte sind bei der SMP400 anders, dort hab ichs in der for-Schleife angepasst.

Bitte um Info, welche Schwächen da noch sind, bzw. ob das halbwegs tragbar für die Prod ist.